### PR TITLE
出力される文字列に含まれる関数名を修正した

### DIFF
--- a/codes/chap04/code_4_6.cpp
+++ b/codes/chap04/code_4_6.cpp
@@ -2,7 +2,7 @@
 using namespace std;
 
 int fibo(int N) {
-    cout << "func(" << N << ") を呼び出しました" << endl;
+    cout << "fibo(" << N << ") を呼び出しました" << endl;
     
     // ベースケース
     if (N == 0) return 0;


### PR DESCRIPTION
書籍48ページのcode 4.6に対応するファイルの文字列で、関数名を`fibo`とすべきところが`func`となっていたため、修正しました。