### PR TITLE
[code_13_3.cpp] Parameter `s` (initial vertex) is not used

### DIFF
--- a/codes/chap13/code_13_3.cpp
+++ b/codes/chap13/code_13_3.cpp
@@ -11,9 +11,9 @@ vector<int> BFS(const Graph &G, int s) {
     vector<int> dist(N, -1); // 全頂点を「未訪問」に初期化
     queue<int> que;
 
-    // 初期条件 (頂点 0 を初期頂点とする)
-    dist[0] = 0;
-    que.push(0); // 0 を橙色頂点にする
+    // 初期条件 (頂点 s を初期頂点とする)
+    dist[s] = 0;
+    que.push(s); // s を橙色頂点にする
 
     // BFS 開始 (キューが空になるまで探索を行う)
     while (!que.empty()) {


### PR DESCRIPTION
The BFS function has parameter `s` for initial vertex, but it is not assigned.

https://github.com/drken1215/book_algorithm_solution/blob/18e934e166248d7c30a755e206825234ec1095f1/codes/chap13/code_13_3.cpp#L7-L9

Instead of assigning `s`, `0` was assigned.

https://github.com/drken1215/book_algorithm_solution/blob/18e934e166248d7c30a755e206825234ec1095f1/codes/chap13/code_13_3.cpp#L14-L16

Maybe this is a bug so I tried to fix it.