### PR TITLE
code 12.5 バケットソートの実装

### DIFF
--- a/codes/chap12/code_12_5.cpp
+++ b/codes/chap12/code_12_5.cpp
@@ -19,6 +19,7 @@ void BucketSort(vector<int> &a) {
     // sum[v]: v 以下の値の個数
     // 値 a[i] が全体の中で何番目に小さいかを求める
     vector<int> sum(MAX, 0);
+    sum[0] = num[0];
     for (int v = 1; v < MAX; ++v) {
         sum[v] = sum[v - 1] + num[v];
     }


### PR DESCRIPTION
sum[0]へ値 _v_ の個数を代入するコードが抜けているようでしたので追記しました。
ご確認よろしくお願いします。
